### PR TITLE
- change test to permit background-color property

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,7 +66,7 @@ describe("index.css", () => {
   it("sets <body> background to #00b3e6", () => {
     const rule = findRule(css.cssRules, "body");
     const hint = "Missing background property for body";
-    expect(rule.style["background"], hint).to.eq("#00b3e6");
+    expect(rule.style["background"]|| rule.style["background-color"], hint).to.eq("#00b3e6");
   });
 
   it("has a rule for <div> tags", () => {
@@ -95,7 +95,7 @@ describe("index.css", () => {
   it("sets <div> background to white", () => {
     const rule = findRule(css.cssRules, "div");
     const hint = "Missing background property for div";
-    expect(rule.style["background"], hint).to.eq("white");
+    expect(rule.style["background"]|| rule.style["background-color"], hint).to.eq("white");
   });
 
   it("sets <div> padding to 30px", () => {


### PR DESCRIPTION
Students will correctly use the `background-color` CSS property to set the background and get an error from the test. There's nothing in the lab that presupposes using the shorthand aspects of the property (i.e. `background` as shorthand for `background-color`, 
`background-image`, `background-position`, `background-size`, `background-repeat`, `background-origin`, `background-clip`,
`background-attachment`), so I can't see a reason why they shouldn't be allowed to use the more specific and semantic `background-color` if they choose to,





